### PR TITLE
Rename API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ implementation "drewhamilton.rxpreferences:rxpreferences-dagger:$version"
 ## Usage
 Get the current value of any preference:
 ```java
-rxPreferences.getInt("Number of examples", 0)
+rxPreferences.getIntOnce("Number of examples", 0)
     .subscribeOn(Schedulers.single())
     .map(size -> newListOfExamples(size))
     .observeOn(AndroidSchedulers.mainThread())
@@ -29,7 +29,7 @@ rxPreferences.getInt("Number of examples", 0)
 
 Observe the initial value plus any changes to a preference:
 ```java
-rxPreferences.observeString("Type of second example", "Float")
+rxPreferences.getStringStream("Type of second example", "Float")
     .subscribeOn(Schedulers.single())
     .map(type -> toActualExample(type))
     .observeOn(AndroidSchedulers.mainThread())

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/app/src/main/java/drewhamilton/rxpreferences/example/edit/EditingFragment.kt
+++ b/app/src/main/java/drewhamilton/rxpreferences/example/edit/EditingFragment.kt
@@ -44,11 +44,11 @@ class EditingFragment : RxFragment() {
       }
     })
 
-    editingViewModel.getExampleString()
+    editingViewModel.getExampleStringOnce()
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { string -> stringValue.setText(string) }
         .trackUntilDestroyView()
-    editingViewModel.getExampleInteger()
+    editingViewModel.getExampleIntegerOnce()
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { integer -> integerValue.setText(integer.toString()) }
         .trackUntilDestroyView()

--- a/app/src/main/java/drewhamilton/rxpreferences/example/edit/EditingViewModel.kt
+++ b/app/src/main/java/drewhamilton/rxpreferences/example/edit/EditingViewModel.kt
@@ -5,9 +5,9 @@ import javax.inject.Inject
 
 class EditingViewModel @Inject constructor(private val exampleRepository: MutableExampleRepository) : ViewModel() {
 
-  fun getExampleString() = exampleRepository.getExampleString()
+  fun getExampleStringOnce() = exampleRepository.getExampleStringOnce()
 
-  fun getExampleInteger() = exampleRepository.getExampleInt()
+  fun getExampleIntegerOnce() = exampleRepository.getExampleIntOnce()
 
   fun setExampleValues(string: String, int: Int) = exampleRepository.changeExampleValues(string, int)
 

--- a/app/src/main/java/drewhamilton/rxpreferences/example/observe/ExampleRepository.kt
+++ b/app/src/main/java/drewhamilton/rxpreferences/example/observe/ExampleRepository.kt
@@ -9,16 +9,16 @@ open class ExampleRepository @Inject constructor(protected val preferences: RxPr
   protected val scheduler
     get() = Schedulers.single()
 
-  fun getExampleString() = preferences.getString(Keys.EXAMPLE_STRING, Defaults.STRING)
+  fun getExampleStringOnce() = preferences.getStringOnce(Keys.EXAMPLE_STRING, Defaults.STRING)
       .subscribeOn(scheduler)
 
-  fun observeExampleString() = preferences.observeString(Keys.EXAMPLE_STRING, Defaults.STRING)
+  fun getExampleStringStream() = preferences.getStringStream(Keys.EXAMPLE_STRING, Defaults.STRING)
       .subscribeOn(scheduler)!!
 
-  fun getExampleInt() = preferences.getInt(Keys.EXAMPLE_INT, Defaults.INT)
+  fun getExampleIntOnce() = preferences.getIntOnce(Keys.EXAMPLE_INT, Defaults.INT)
       .subscribeOn(scheduler)
 
-  fun observeExampleInt() = preferences.observeInt(Keys.EXAMPLE_INT, Defaults.INT)
+  fun getExampleIntStream() = preferences.getIntStream(Keys.EXAMPLE_INT, Defaults.INT)
       .subscribeOn(scheduler)!!
 
   protected object Keys {

--- a/app/src/main/java/drewhamilton/rxpreferences/example/observe/ObservationFragment.kt
+++ b/app/src/main/java/drewhamilton/rxpreferences/example/observe/ObservationFragment.kt
@@ -33,11 +33,11 @@ class ObservationFragment : RxFragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    observationViewModel.observeExampleString()
+    observationViewModel.getExampleStringStream()
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { stringValue.text = it }
         .trackUntilDestroyView()
-    observationViewModel.observeExampleInt()
+    observationViewModel.getExampleIntStream()
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { integerValue.text = it.toString() }
         .trackUntilDestroyView()

--- a/app/src/main/java/drewhamilton/rxpreferences/example/observe/ObservationViewModel.kt
+++ b/app/src/main/java/drewhamilton/rxpreferences/example/observe/ObservationViewModel.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 class ObservationViewModel @Inject constructor(private val exampleRepository: ExampleRepository) : ViewModel() {
 
-  fun observeExampleString() = exampleRepository.observeExampleString()
+  fun getExampleStringStream() = exampleRepository.getExampleStringStream()
 
-  fun observeExampleInt() = exampleRepository.observeExampleInt()
+  fun getExampleIntStream() = exampleRepository.getExampleIntStream()
 }

--- a/dagger/build.gradle
+++ b/dagger/build.gradle
@@ -35,6 +35,7 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
 }
 
 apply from: 'publish.gradle'

--- a/dagger/src/main/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponent.kt
+++ b/dagger/src/main/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponent.kt
@@ -32,6 +32,7 @@ interface RxPreferencesComponent {
     /**
      * @return a concrete [RxPreferencesComponent] instance
      */
-    fun create(sharedPreferences: SharedPreferences) = DaggerRxPreferencesComponent.factory().create(sharedPreferences)
+    @JvmStatic fun create(sharedPreferences: SharedPreferences): RxPreferencesComponent =
+        DaggerRxPreferencesComponent.factory().create(sharedPreferences)
   }
 }

--- a/dagger/src/test/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponentTest.java
+++ b/dagger/src/test/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponentTest.java
@@ -17,7 +17,7 @@ public final class RxPreferencesComponentTest {
 
   @Test
   public void factory_createsExpectedRxPreferencesInstance() {
-    final RxPreferencesComponent component = RxPreferencesComponent.Companion.create(mockSharedPreferences);
+    final RxPreferencesComponent component = RxPreferencesComponent.create(mockSharedPreferences);
     final RxPreferences rxPreferences = component.rxPreferences();
 
     final String testKey = "Test key";

--- a/dagger/src/test/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponentTest.java
+++ b/dagger/src/test/java/drewhamilton/rxpreferences/dagger/RxPreferencesComponentTest.java
@@ -22,7 +22,7 @@ public final class RxPreferencesComponentTest {
 
     final String testKey = "Test key";
     //noinspection ResultOfMethodCallIgnored: function return values are tested in main module
-    rxPreferences.contains(testKey).blockingGet();
+    rxPreferences.containsOnce(testKey).blockingGet();
 
     verify(mockSharedPreferences).contains(testKey);
     verifyNoMoreInteractions(mockSharedPreferences);

--- a/ktx/build.gradle
+++ b/ktx/build.gradle
@@ -37,6 +37,7 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/ktx/src/main/java/drewhamilton/rxpreferences/RxPreferences.kt
+++ b/ktx/src/main/java/drewhamilton/rxpreferences/RxPreferences.kt
@@ -12,8 +12,8 @@ import io.reactivex.Observable
  * @throws [IllegalArgumentException] if the stored string does not resolve to a valid
  * name for a value of type [E].
  */
-inline fun <reified E : Enum<E>> RxPreferences.getEnum(key: String, defaultValue: E) =
-    getString(key, defaultValue.name)
+inline fun <reified E : Enum<E>> RxPreferences.getEnumOnce(key: String, defaultValue: E) =
+    getStringOnce(key, defaultValue.name)
         .map { enumValueOf<E>(it) }
 
 /**
@@ -28,8 +28,8 @@ inline fun <reified E : Enum<E>> RxPreferences.getEnum(key: String, defaultValue
  * @throws [IllegalArgumentException] if the stored string does not resolve to a valid
  * name for a value of type [E].
  */
-inline fun <reified E : Enum<E>> RxPreferences.observeEnum(key: String, defaultValue: E) =
-    observeString(key, defaultValue.name)
+inline fun <reified E : Enum<E>> RxPreferences.getEnumStream(key: String, defaultValue: E) =
+    getStringStream(key, defaultValue.name)
         .map { enumValueOf<E>(it) }!!
 
 /**
@@ -42,8 +42,8 @@ inline fun <reified E : Enum<E>> RxPreferences.observeEnum(key: String, defaultV
  * @throws [IndexOutOfBoundsException] if the stored int does not resolve to a valid
  * ordinal for a value of type [E].
  */
-inline fun <reified E : Enum<E>> RxPreferences.getEnumByOrdinal(key: String, defaultValue: E) =
-    getInt(key, defaultValue.ordinal)
+inline fun <reified E : Enum<E>> RxPreferences.getEnumByOrdinalOnce(key: String, defaultValue: E) =
+    getIntOnce(key, defaultValue.ordinal)
         .map { enumValues<E>()[it] }
 
 /**
@@ -57,8 +57,8 @@ inline fun <reified E : Enum<E>> RxPreferences.getEnumByOrdinal(key: String, def
  * @throws [IndexOutOfBoundsException] if the stored int does not resolve to a valid
  * ordinal for a value of type [E].
  */
-inline fun <reified E : Enum<E>> RxPreferences.observeEnumByOrdinal(key: String, defaultValue: E) =
-    observeInt(key, defaultValue.ordinal)
+inline fun <reified E : Enum<E>> RxPreferences.getEnumByOrdinalStream(key: String, defaultValue: E) =
+    getIntStream(key, defaultValue.ordinal)
         .map { enumValues<E>()[it] }!!
 
 /**

--- a/ktx/src/test/java/drewhamilton/rxpreferences/RxPreferencesExtensionsTest.kt
+++ b/ktx/src/test/java/drewhamilton/rxpreferences/RxPreferencesExtensionsTest.kt
@@ -182,7 +182,7 @@ class RxPreferencesExtensionsTest {
   //region get preference stream
   @Test
   fun `getEnumStream emits on listener update`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
@@ -210,7 +210,7 @@ class RxPreferencesExtensionsTest {
 
   @Test
   fun `getEnumStream emits current value on subscribe`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
@@ -228,7 +228,7 @@ class RxPreferencesExtensionsTest {
 
   @Test
   fun `getEnumStream unregisters listener on unsubscribe`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
@@ -250,7 +250,7 @@ class RxPreferencesExtensionsTest {
 
   @Test
   fun `getEnumByOrdinalStream emits on listener update`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum ordinal key"
     val testValue = PreferenceType.STRING
     val testDefault = PreferenceType.LONG
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
@@ -278,7 +278,7 @@ class RxPreferencesExtensionsTest {
 
   @Test
   fun `getEnumByOrdinalStream emits current value on subscribe`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum ordinal key"
     val testValue = PreferenceType.STRING
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
@@ -296,7 +296,7 @@ class RxPreferencesExtensionsTest {
 
   @Test
   fun `getEnumByOrdinalStream unregisters listener on unsubscribe`() {
-    val testKey = "Test PreferenceType key"
+    val testKey = "Test enum ordinal key"
     val testValue = PreferenceType.FLOAT
     val testDefault = PreferenceType.STRING
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)

--- a/ktx/src/test/java/drewhamilton/rxpreferences/RxPreferencesExtensionsTest.kt
+++ b/ktx/src/test/java/drewhamilton/rxpreferences/RxPreferencesExtensionsTest.kt
@@ -60,15 +60,15 @@ class RxPreferencesExtensionsTest {
   }
 
   //region RxPreferences
-  //region get preference
+  //region get preference once
   @Test
-  fun `getEnum emits from internal preferences`() {
+  fun `getEnumOnce emits from internal preferences`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.LONG
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
 
-    val subscription = rxPreferences.getEnum(testKey, testDefault)
+    val subscription = rxPreferences.getEnumOnce(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -79,13 +79,13 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `getEnum gets after subscribe`() {
+  fun `getEnumOnce gets after subscribe`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.LONG
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
 
-    val subscription = rxPreferences.getEnum(testKey, testDefault)
+    val subscription = rxPreferences.getEnumOnce(testKey, testDefault)
         .subscribeOn(testScheduler)
         .subscribe()
         .trackUntilTearDown()
@@ -106,13 +106,13 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `getEnumByOrdinal emits from internal preferences`() {
+  fun `getEnumByOrdinalOnce emits from internal preferences`() {
     val testKey = "Test PreferenceType ordinal key"
     val testValue = PreferenceType.FLOAT
     val testDefault = PreferenceType.STRING
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
 
-    val subscription = rxPreferences.getEnumByOrdinal(testKey, testDefault)
+    val subscription = rxPreferences.getEnumByOrdinalOnce(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -123,13 +123,13 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `getEnumByOrdinal gets after subscribe`() {
+  fun `getEnumByOrdinalOnce gets after subscribe`() {
     val testKey = "Test PreferenceType ordinal key"
     val testValue = PreferenceType.FLOAT
     val testDefault = PreferenceType.STRING
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
 
-    val subscription = rxPreferences.getEnumByOrdinal(testKey, testDefault)
+    val subscription = rxPreferences.getEnumByOrdinalOnce(testKey, testDefault)
         .subscribeOn(testScheduler)
         .subscribe()
         .trackUntilTearDown()
@@ -179,15 +179,15 @@ class RxPreferencesExtensionsTest {
   }
   //endregion
 
-  //region observe preference
+  //region get preference stream
   @Test
-  fun `observeEnum emits on listener update`() {
+  fun `getEnumStream emits on listener update`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
 
-    val subscription = rxPreferences.observeEnum(testKey, testDefault)
+    val subscription = rxPreferences.getEnumStream(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -209,31 +209,31 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `observeEnum emits current value on subscribe`() {
+  fun `getEnumStream emits current value on subscribe`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
 
-    val subscription = rxPreferences.observeEnum(testKey, testDefault)
+    val subscription = rxPreferences.getEnumStream(testKey, testDefault)
         .subscribeOn(testScheduler)
         .subscribe()
         .trackUntilTearDown()
 
-    verifyObserveBeforeSubscribe(subscription)
+    verifyGetStreamBeforeSubscribe(subscription)
 
     advanceScheduler()
-    verifyObserveAfterSubscribe(PreferenceType.STRING, testKey, testDefault.name, subscription)
+    verifyGetStreamAfterSubscribe(PreferenceType.STRING, testKey, testDefault.name, subscription)
   }
 
   @Test
-  fun `observeEnum unregisters listener on unsubscribe`() {
+  fun `getEnumStream unregisters listener on unsubscribe`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.INT
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.STRING, testKey, testValue.name)
 
-    val subscription = rxPreferences.observeEnum(testKey, testDefault)
+    val subscription = rxPreferences.getEnumStream(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -249,13 +249,13 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `observeEnumByOrdinal emits on listener update`() {
+  fun `getEnumByOrdinalStream emits on listener update`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.STRING
     val testDefault = PreferenceType.LONG
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
 
-    val subscription = rxPreferences.observeEnumByOrdinal(testKey, testDefault)
+    val subscription = rxPreferences.getEnumByOrdinalStream(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -277,31 +277,31 @@ class RxPreferencesExtensionsTest {
   }
 
   @Test
-  fun `observeEnumByOrdinal emits current value on subscribe`() {
+  fun `getEnumByOrdinalStream emits current value on subscribe`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.STRING
     val testDefault = PreferenceType.BOOLEAN
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
 
-    val subscription = rxPreferences.observeEnumByOrdinal(testKey, testDefault)
+    val subscription = rxPreferences.getEnumByOrdinalStream(testKey, testDefault)
         .subscribeOn(testScheduler)
         .subscribe()
         .trackUntilTearDown()
 
-    verifyObserveBeforeSubscribe(subscription)
+    verifyGetStreamBeforeSubscribe(subscription)
 
     advanceScheduler()
-    verifyObserveAfterSubscribe(PreferenceType.INT, testKey, testDefault.ordinal, subscription)
+    verifyGetStreamAfterSubscribe(PreferenceType.INT, testKey, testDefault.ordinal, subscription)
   }
 
   @Test
-  fun `observeEnumByOrdinal unregisters listener on unsubscribe`() {
+  fun `getEnumByOrdinalStream unregisters listener on unsubscribe`() {
     val testKey = "Test PreferenceType key"
     val testValue = PreferenceType.FLOAT
     val testDefault = PreferenceType.STRING
     mockGet(PreferenceType.INT, testKey, testValue.ordinal)
 
-    val subscription = rxPreferences.observeEnumByOrdinal(testKey, testDefault)
+    val subscription = rxPreferences.getEnumByOrdinalStream(testKey, testDefault)
         .test()
         .trackUntilTearDown()
 
@@ -316,14 +316,14 @@ class RxPreferencesExtensionsTest {
     verify(mockSharedPreferences).unregisterOnSharedPreferenceChangeListener(listener)
   }
 
-  private fun verifyObserveBeforeSubscribe(subscription: Disposable) {
+  private fun verifyGetStreamBeforeSubscribe(subscription: Disposable) {
     // Before subscribing, there are no interactions with the internal preferences:
     verifyNoMoreInteractions(mockSharedPreferences)
     verifyNoMoreInteractions(mockSharedPreferencesEditor)
     assertFalse(subscription.isDisposed)
   }
 
-  private fun verifyObserveAfterSubscribe(
+  private fun verifyGetStreamAfterSubscribe(
       type: PreferenceType,
       key: String,
       defaultValue: Any,

--- a/rxpreferences/src/main/java/drewhamilton/rxpreferences/RxPreferences.java
+++ b/rxpreferences/src/main/java/drewhamilton/rxpreferences/RxPreferences.java
@@ -36,7 +36,7 @@ public final class RxPreferences {
    * @return a map containing a list of pairs key/value representing the preferences.
    */
   @NonNull
-  public Single<Map<String, ?>> getAll() {
+  public Single<Map<String, ?>> getAllOnce() {
     return Single.fromCallable(preferences::getAll);
   }
 
@@ -49,8 +49,8 @@ public final class RxPreferences {
    * each time any of the preferences change.
    */
   @NonNull
-  public Observable<Map<String, ?>> observeAll() {
-    return getAll()
+  public Observable<Map<String, ?>> getAllStream() {
+    return getAllOnce()
         .toObservable()
         .mergeWith(Observable.create(emitter -> {
           RxAllPreferencesListener listener = new RxAllPreferencesListener(emitter);
@@ -66,7 +66,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a String.
    */
   @NonNull
-  public Single<String> getString(@NonNull String key, @NonNull String defaultValue) {
+  public Single<String> getStringOnce(@NonNull String key, @NonNull String defaultValue) {
     return Single.fromCallable(() -> preferences.getString(key, defaultValue));
   }
 
@@ -80,8 +80,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a String.
    */
   @NonNull
-  public Observable<String> observeString(@NonNull String key, @NonNull String defaultValue) {
-    return getString(key, defaultValue)
+  public Observable<String> getStringStream(@NonNull String key, @NonNull String defaultValue) {
+    return getStringOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getString));
   }
@@ -97,7 +97,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a {@link Set}.
    */
   @NonNull
-  public Single<Set<String>> getStringSet(@NonNull String key, @NonNull Set<String> defaultValues) {
+  public Single<Set<String>> getStringSetOnce(@NonNull String key, @NonNull Set<String> defaultValues) {
     return Single.fromCallable(() -> preferences.getStringSet(key, defaultValues));
   }
 
@@ -111,8 +111,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a {@link Set}.
    */
   @NonNull
-  public Observable<Set<String>> observeStringSet(@NonNull String key, @NonNull Set<String> defaultValue) {
-    return getStringSet(key, defaultValue)
+  public Observable<Set<String>> getStringSetStream(@NonNull String key, @NonNull Set<String> defaultValue) {
+    return getStringSetOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getStringSet));
   }
@@ -125,7 +125,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not an int.
    */
   @NonNull
-  public Single<Integer> getInt(@NonNull String key, int defaultValue) {
+  public Single<Integer> getIntOnce(@NonNull String key, int defaultValue) {
     return Single.fromCallable(() -> preferences.getInt(key, defaultValue));
   }
 
@@ -139,8 +139,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not an int.
    */
   @NonNull
-  public Observable<Integer> observeInt(@NonNull String key, int defaultValue) {
-    return getInt(key, defaultValue)
+  public Observable<Integer> getIntStream(@NonNull String key, int defaultValue) {
+    return getIntOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getInt));
   }
@@ -153,7 +153,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a long.
    */
   @NonNull
-  public Single<Long> getLong(@NonNull String key, long defaultValue) {
+  public Single<Long> getLongOnce(@NonNull String key, long defaultValue) {
     return Single.fromCallable(() -> preferences.getLong(key, defaultValue));
   }
 
@@ -167,8 +167,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a long.
    */
   @NonNull
-  public Observable<Long> observeLong(@NonNull String key, long defaultValue) {
-    return getLong(key, defaultValue)
+  public Observable<Long> getLongStream(@NonNull String key, long defaultValue) {
+    return getLongOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getLong));
   }
@@ -181,7 +181,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a float.
    */
   @NonNull
-  public Single<Float> getFloat(@NonNull String key, float defaultValue) {
+  public Single<Float> getFloatOnce(@NonNull String key, float defaultValue) {
     return Single.fromCallable(() -> preferences.getFloat(key, defaultValue));
   }
 
@@ -195,8 +195,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a float.
    */
   @NonNull
-  public Observable<Float> observeFloat(@NonNull String key, float defaultValue) {
-    return getFloat(key, defaultValue)
+  public Observable<Float> getFloatStream(@NonNull String key, float defaultValue) {
+    return getFloatOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getFloat));
   }
@@ -209,7 +209,7 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a boolean.
    */
   @NonNull
-  public Single<Boolean> getBoolean(@NonNull String key, boolean defaultValue) {
+  public Single<Boolean> getBooleanOnce(@NonNull String key, boolean defaultValue) {
     return Single.fromCallable(() -> preferences.getBoolean(key, defaultValue));
   }
 
@@ -223,8 +223,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a boolean.
    */
   @NonNull
-  public Observable<Boolean> observeBoolean(@NonNull String key, boolean defaultValue) {
-    return getBoolean(key, defaultValue)
+  public Observable<Boolean> getBooleanStream(@NonNull String key, boolean defaultValue) {
+    return getBooleanOnce(key, defaultValue)
         .toObservable()
         .mergeWith(createPreferenceObservable(key, defaultValue, SharedPreferences::getBoolean));
   }
@@ -235,7 +235,7 @@ public final class RxPreferences {
    * @return true if the preference exists in the preferences, otherwise false.
    */
   @NonNull
-  public Single<Boolean> contains(@NonNull String key) {
+  public Single<Boolean> containsOnce(@NonNull String key) {
     return Single.fromCallable(() -> preferences.contains(key));
   }
 
@@ -247,8 +247,8 @@ public final class RxPreferences {
    * @throws ClassCastException if there is a preference with this name that is not a long.
    */
   @NonNull
-  public Observable<Boolean> observeContains(@NonNull String key) {
-    return contains(key)
+  public Observable<Boolean> containsStream(@NonNull String key) {
+    return containsOnce(key)
         .toObservable()
         .mergeWith(Observable.create(emitter -> {
           RxPreferenceContainsListener listener = new RxPreferenceContainsListener(key, emitter);

--- a/rxpreferences/src/test/java/drewhamilton/rxpreferences/RxPreferencesTest.java
+++ b/rxpreferences/src/test/java/drewhamilton/rxpreferences/RxPreferencesTest.java
@@ -54,13 +54,13 @@ public final class RxPreferencesTest {
   //region RxPreferences
   //region all preferences
   @Test
-  public void getAll_emitsMapFromInternalPreferences() {
+  public void getAllOnce_emitsMapFromInternalPreferences() {
     final Map<String, ?> testMap = Collections.singletonMap("Made up map key", 23498);
 
     //noinspection unchecked: Not sure why this cast is needed but it works
     when(mockSharedPreferences.getAll()).thenReturn((Map) testMap);
 
-    final TestObserver<Map<String, ?>> subscription = rxPreferences.getAll()
+    final TestObserver<Map<String, ?>> subscription = rxPreferences.getAllOnce()
         .test();
     subscriptions.add(subscription);
 
@@ -71,12 +71,12 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void getAll_getsAfterSubscribe() {
+  public void getAllOnce_getsAfterSubscribe() {
     final Map<String, ?> testMap = Collections.singletonMap("Made up map key", 234234);
     //noinspection unchecked: Not sure why this cast is needed but it works
     when(mockSharedPreferences.getAll()).thenReturn((Map) testMap);
 
-    final Disposable subscription = rxPreferences.getAll()
+    final Disposable subscription = rxPreferences.getAllOnce()
         .subscribeOn(testScheduler)
         .subscribe();
     subscriptions.add(subscription);
@@ -89,12 +89,12 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeAll_emitsOnListenerUpdate() {
+  public void getAllStream_emitsOnListenerUpdate() {
     final Map<String, ?> returnedMap = Collections.singletonMap("Test dummy key", 234);
     //noinspection unchecked
     when(mockSharedPreferences.getAll()).thenReturn((Map) returnedMap);
 
-    final TestObserver<Map<String, ?>> subscription = rxPreferences.observeAll().test();
+    final TestObserver<Map<String, ?>> subscription = rxPreferences.getAllStream().test();
     subscriptions.add(subscription);
 
     subscription
@@ -117,17 +117,17 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeAll_emitsCurrentValueOnSubscribe() {
+  public void getAllStream_emitsCurrentValueOnSubscribe() {
     final Map<String, ?> returnedMap = Collections.singletonMap("Test dummy long key", 23453534523L);
     //noinspection unchecked
     when(mockSharedPreferences.getAll()).thenReturn((Map) returnedMap);
 
-    final Disposable subscription = rxPreferences.observeAll()
+    final Disposable subscription = rxPreferences.getAllStream()
         .subscribeOn(testScheduler)
         .subscribe();
     subscriptions.add(subscription);
 
-    verifyObserveBeforeSubscribe(subscription);
+    verifyGetStreamBeforeSubscribe(subscription);
 
     advanceScheduler();
 
@@ -139,12 +139,12 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeAll_unregistersListenerOnUnsubscribe() {
+  public void getAllStream_unregistersListenerOnUnsubscribe() {
     final Map<String, ?> returnedMap = Collections.singletonMap("Test dummy long key", 23453534523L);
     //noinspection unchecked
     when(mockSharedPreferences.getAll()).thenReturn((Map) returnedMap);
 
-    final TestObserver<Map<String, ?>> subscription = rxPreferences.observeAll().test();
+    final TestObserver<Map<String, ?>> subscription = rxPreferences.getAllStream().test();
     subscriptions.add(subscription);
 
     final ArgumentCaptor<SharedPreferences.OnSharedPreferenceChangeListener> listenerCaptor =
@@ -160,75 +160,75 @@ public final class RxPreferencesTest {
   }
   //endregion
 
-  //region get preference
+  //region get preference once
   @Test
-  public void getString_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.STRING, "Test value", "Test default");
+  public void getStringOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.STRING, "Test value", "Test default");
   }
 
   @Test
-  public void getString_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.STRING, "Test value", "Test default");
+  public void getStringOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.STRING, "Test value", "Test default");
   }
 
   @Test
-  public void getStringSet_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.STRING_SET, Collections.singleton("Test value"),
+  public void getStringSetOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.STRING_SET, Collections.singleton("Test value"),
         Collections.singleton("Test default"));
   }
 
   @Test
-  public void getStringSet_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.STRING_SET, Collections.singleton("Test value"),
+  public void getStringSetOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.STRING_SET, Collections.singleton("Test value"),
         Collections.singleton("Test default"));
   }
 
   @Test
-  public void getInt_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.INT, 2332, -987);
+  public void getIntOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.INT, 2332, -987);
   }
 
   @Test
-  public void getInt_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.INT, 2332, -987);
+  public void getIntOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.INT, 2332, -987);
   }
 
   @Test
-  public void getLong_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.LONG, 342342342343L, -38948985934859L);
+  public void getLongOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.LONG, 342342342343L, -38948985934859L);
   }
 
   @Test
-  public void getLong_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.LONG, 342342342343L, -38948985934859L);
+  public void getLongOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.LONG, 342342342343L, -38948985934859L);
   }
 
   @Test
-  public void getFloat_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.FLOAT, 234.432f, -987.654f);
+  public void getFloatOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.FLOAT, 234.432f, -987.654f);
   }
 
   @Test
-  public void getFloat_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.FLOAT, 234.432f, -987.654f);
+  public void getFloatOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.FLOAT, 234.432f, -987.654f);
   }
 
   @Test
-  public void getBoolean_emitsFromInternalPreferences() {
-    testGetMethod_emitsFromInternalPreferences(PreferenceType.BOOLEAN, true, false);
+  public void getBooleanOnce_emitsFromInternalPreferences() {
+    testGetOnceMethod_emitsFromInternalPreferences(PreferenceType.BOOLEAN, true, false);
   }
 
   @Test
-  public void getBoolean_getsAfterSubscribe() {
-    testGetMethod_getsAfterSubscribe(PreferenceType.BOOLEAN, true, false);
+  public void getBooleanOnce_getsAfterSubscribe() {
+    testGetOnceMethod_getsAfterSubscribe(PreferenceType.BOOLEAN, true, false);
   }
 
-  private void testGetMethod_emitsFromInternalPreferences(PreferenceType type, Object returnedValue,
+  private void testGetOnceMethod_emitsFromInternalPreferences(PreferenceType type, Object returnedValue,
       Object defaultValue) {
     assertNotNull(type);
     assertNotNull(returnedValue);
     assertNotNull(defaultValue);
-    final String valueTypeFailureMessage = "Testing #get method of type " + type + " requires a value of type "
+    final String valueTypeFailureMessage = "Testing #getOnce method of type " + type + " requires a value of type "
         + type.valueClass.getSimpleName() + ", but the provided value was of type "
         + returnedValue.getClass().getSimpleName();
     assertTrue(valueTypeFailureMessage, type.valueClass.isAssignableFrom(returnedValue.getClass()));
@@ -236,7 +236,7 @@ public final class RxPreferencesTest {
     final String testKey = "Test " + type + " key";
     mockGet(type, testKey, returnedValue);
 
-    final TestObserver<Object> subscription = get(rxPreferences, type, testKey, defaultValue)
+    final TestObserver<Object> subscription = getOnce(rxPreferences, type, testKey, defaultValue)
         .test();
     subscriptions.add(subscription);
 
@@ -246,11 +246,11 @@ public final class RxPreferencesTest {
         .assertValue(returnedValue);
   }
 
-  private void testGetMethod_getsAfterSubscribe(PreferenceType type, Object returnedValue, Object defaultValue) {
+  private void testGetOnceMethod_getsAfterSubscribe(PreferenceType type, Object returnedValue, Object defaultValue) {
     assertNotNull(type);
     assertNotNull(returnedValue);
     assertNotNull(defaultValue);
-    final String valueTypeFailureMessage = "Testing #get method of type " + type + " requires a value of type "
+    final String valueTypeFailureMessage = "Testing #getOnce method of type " + type + " requires a value of type "
         + type.valueClass.getSimpleName() + ", but the provided value was of type "
         + returnedValue.getClass().getSimpleName();
     assertTrue(valueTypeFailureMessage, type.valueClass.isAssignableFrom(returnedValue.getClass()));
@@ -258,7 +258,7 @@ public final class RxPreferencesTest {
     final String testKey = "Test " + type + " key";
     mockGet(type, testKey, returnedValue);
 
-    final Disposable subscription = getOnTestScheduler(type, testKey, defaultValue);
+    final Disposable subscription = getOnceOnTestScheduler(type, testKey, defaultValue);
     subscriptions.add(subscription);
 
     verifyGetBeforeSubscribe(subscription);
@@ -267,8 +267,8 @@ public final class RxPreferencesTest {
     verifyGetAfterSubscribe(type, testKey, defaultValue, subscription);
   }
 
-  private Disposable getOnTestScheduler(PreferenceType type, String key, Object defaultValue) {
-    return get(rxPreferences, type, key, defaultValue)
+  private Disposable getOnceOnTestScheduler(PreferenceType type, String key, Object defaultValue) {
+    return getOnce(rxPreferences, type, key, defaultValue)
         .subscribeOn(testScheduler)
         .subscribe();
   }
@@ -338,27 +338,28 @@ public final class RxPreferencesTest {
     }
   }
 
-  private static <T> Single<T> get(RxPreferences rxPreferences, PreferenceType type, String key, Object defaultValue) {
+  private static <T> Single<T> getOnce(RxPreferences rxPreferences, PreferenceType type, String key,
+      Object defaultValue) {
     final Single preferenceSingle;
     switch (type) {
       case STRING:
-        preferenceSingle = rxPreferences.getString(key, (String) defaultValue);
+        preferenceSingle = rxPreferences.getStringOnce(key, (String) defaultValue);
         break;
       case STRING_SET:
         //noinspection unchecked
-        preferenceSingle = rxPreferences.getStringSet(key, (Set<String>) defaultValue);
+        preferenceSingle = rxPreferences.getStringSetOnce(key, (Set<String>) defaultValue);
         break;
       case INT:
-        preferenceSingle = rxPreferences.getInt(key, (int) defaultValue);
+        preferenceSingle = rxPreferences.getIntOnce(key, (int) defaultValue);
         break;
       case LONG:
-        preferenceSingle = rxPreferences.getLong(key, (long) defaultValue);
+        preferenceSingle = rxPreferences.getLongOnce(key, (long) defaultValue);
         break;
       case FLOAT:
-        preferenceSingle = rxPreferences.getFloat(key, (float) defaultValue);
+        preferenceSingle = rxPreferences.getFloatOnce(key, (float) defaultValue);
         break;
       case BOOLEAN:
-        preferenceSingle = rxPreferences.getBoolean(key, (boolean) defaultValue);
+        preferenceSingle = rxPreferences.getBooleanOnce(key, (boolean) defaultValue);
         break;
       default:
         fail("Unknown preference type: " + type);
@@ -370,105 +371,105 @@ public final class RxPreferencesTest {
   }
   //endregion
 
-  //region observe preference
+  //region get preference stream
   @Test
-  public void observeString_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.STRING, "String value", "Default string");
+  public void getStringStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.STRING, "String value", "Default string");
   }
 
   @Test
-  public void observeString_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.STRING, "Current value", "Default value");
+  public void getStringStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.STRING, "Current value", "Default value");
   }
 
   @Test
-  public void observeString_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.STRING, "Dummy value", "Default value");
+  public void getStringStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.STRING, "Dummy value", "Default value");
   }
 
   @Test
-  public void observeStringSet_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.STRING_SET, Collections.singleton("String value"),
+  public void getStringSetStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.STRING_SET, Collections.singleton("String value"),
         Collections.singleton("Default string"));
   }
 
   @Test
-  public void observeStringSet_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.STRING_SET, Collections.singleton("Current value"),
+  public void getStringSetStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.STRING_SET, Collections.singleton("Current value"),
         Collections.singleton("Default value"));
   }
 
   @Test
-  public void observeStringSet_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.STRING_SET, Collections.singleton("Dummy value"),
+  public void getStringSetStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.STRING_SET, Collections.singleton("Dummy value"),
         Collections.singleton("Default value"));
   }
 
   @Test
-  public void observeInt_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.INT, 123, -321);
+  public void getIntStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.INT, 123, -321);
   }
 
   @Test
-  public void observeInt_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.INT, 123, -321);
+  public void getIntStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.INT, 123, -321);
   }
 
   @Test
-  public void observeInt_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.INT, 123, -321);
+  public void getIntStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.INT, 123, -321);
   }
 
   @Test
-  public void observeLong_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.LONG, 12345678900L, -9876543210L);
+  public void getLongStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.LONG, 12345678900L, -9876543210L);
   }
 
   @Test
-  public void observeLong_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.LONG, 12345678900L, -9876543210L);
+  public void getLongStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.LONG, 12345678900L, -9876543210L);
   }
 
   @Test
-  public void observeLong_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.LONG, 12345678900L, -9876543210L);
+  public void getLongStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.LONG, 12345678900L, -9876543210L);
   }
 
   @Test
-  public void observeFloat_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.FLOAT, 123.456f, -321.987f);
+  public void getFloatStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.FLOAT, 123.456f, -321.987f);
   }
 
   @Test
-  public void observeFloat_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.FLOAT, 123.456f, -321.987f);
+  public void getFloatStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.FLOAT, 123.456f, -321.987f);
   }
 
   @Test
-  public void observeFloat_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.FLOAT, 123.456f, -321.987f);
+  public void getFloatStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.FLOAT, 123.456f, -321.987f);
   }
 
   @Test
-  public void observeBoolean_emitsOnListenerUpdate() {
-    testObserve_emitsOnListenerUpdate(PreferenceType.BOOLEAN, true, false);
+  public void getBooleanStream_emitsOnListenerUpdate() {
+    testGetStream_emitsOnListenerUpdate(PreferenceType.BOOLEAN, true, false);
   }
 
   @Test
-  public void observeBoolean_emitsCurrentValueOnSubscribe() {
-    testObserve_emitsCurrentValueOnSubscribe(PreferenceType.BOOLEAN, true, false);
+  public void getBooleanStream_emitsCurrentValueOnSubscribe() {
+    testGetStream_emitsCurrentValueOnSubscribe(PreferenceType.BOOLEAN, true, false);
   }
 
   @Test
-  public void observeBoolean_unregistersListenerOnUnsubscribe() {
-    testObserve_unregistersListenerOnUnsubscribe(PreferenceType.BOOLEAN, true, false);
+  public void getBooleanStream_unregistersListenerOnUnsubscribe() {
+    testGetStream_unregistersListenerOnUnsubscribe(PreferenceType.BOOLEAN, true, false);
   }
 
-  private void testObserve_emitsOnListenerUpdate(PreferenceType type, Object returnedValue, Object defaultValue) {
+  private void testGetStream_emitsOnListenerUpdate(PreferenceType type, Object returnedValue, Object defaultValue) {
     final String testKey = "Test " + type + " key";
     mockGet(type, testKey, returnedValue);
 
-    final TestObserver<Object> subscription = observe(rxPreferences, type, testKey, defaultValue).test();
+    final TestObserver<Object> subscription = getStream(rxPreferences, type, testKey, defaultValue).test();
     subscriptions.add(subscription);
 
     subscription
@@ -489,28 +490,28 @@ public final class RxPreferencesTest {
         .assertValues(returnedValue, returnedValue);
   }
 
-  private void testObserve_emitsCurrentValueOnSubscribe(PreferenceType type, Object returnedValue,
+  private void testGetStream_emitsCurrentValueOnSubscribe(PreferenceType type, Object returnedValue,
       Object defaultValue) {
     final String testKey = "Test " + type + " key";
     mockGet(type, testKey, returnedValue);
 
-    final Disposable subscription = observe(rxPreferences, type, testKey, defaultValue)
+    final Disposable subscription = getStream(rxPreferences, type, testKey, defaultValue)
         .subscribeOn(testScheduler)
         .subscribe();
     subscriptions.add(subscription);
 
-    verifyObserveBeforeSubscribe(subscription);
+    verifyGetStreamBeforeSubscribe(subscription);
 
     advanceScheduler();
-    verifyObserveAfterSubscribe(type, testKey, defaultValue, subscription);
+    verifyGetStreamAfterSubscribe(type, testKey, defaultValue, subscription);
   }
 
-  private void testObserve_unregistersListenerOnUnsubscribe(PreferenceType type, Object returnedValue,
+  private void testGetStream_unregistersListenerOnUnsubscribe(PreferenceType type, Object returnedValue,
       Object defaultValue) {
     final String testKey = "Test " + type + " key";
     mockGet(type, testKey, returnedValue);
 
-    final TestObserver<Object> subscription = observe(rxPreferences, type, testKey, defaultValue).test();
+    final TestObserver<Object> subscription = getStream(rxPreferences, type, testKey, defaultValue).test();
     subscriptions.add(subscription);
 
     final ArgumentCaptor<SharedPreferences.OnSharedPreferenceChangeListener> listenerCaptor =
@@ -525,11 +526,11 @@ public final class RxPreferencesTest {
     verify(mockSharedPreferences).unregisterOnSharedPreferenceChangeListener(listener);
   }
 
-  private void verifyObserveBeforeSubscribe(Disposable subscription) {
+  private void verifyGetStreamBeforeSubscribe(Disposable subscription) {
     verifyGetBeforeSubscribe(subscription);
   }
 
-  private void verifyObserveAfterSubscribe(PreferenceType type, String key, Object defaultValue,
+  private void verifyGetStreamAfterSubscribe(PreferenceType type, String key, Object defaultValue,
       Disposable subscription) {
     verifyNoMoreInteractions(mockSharedPreferencesEditor);
 
@@ -540,27 +541,28 @@ public final class RxPreferencesTest {
     assertFalse(subscription.isDisposed());
   }
 
-  private static <T> Observable<T> observe(RxPreferences rxPreferences, PreferenceType type, String key, Object defaultValue) {
+  private static <T> Observable<T> getStream(RxPreferences rxPreferences, PreferenceType type, String key,
+      Object defaultValue) {
     final Observable preferenceObservable;
     switch (type) {
       case STRING:
-        preferenceObservable = rxPreferences.observeString(key, (String) defaultValue);
+        preferenceObservable = rxPreferences.getStringStream(key, (String) defaultValue);
         break;
       case STRING_SET:
         //noinspection unchecked
-        preferenceObservable = rxPreferences.observeStringSet(key, (Set<String>) defaultValue);
+        preferenceObservable = rxPreferences.getStringSetStream(key, (Set<String>) defaultValue);
         break;
       case INT:
-        preferenceObservable = rxPreferences.observeInt(key, (int) defaultValue);
+        preferenceObservable = rxPreferences.getIntStream(key, (int) defaultValue);
         break;
       case LONG:
-        preferenceObservable = rxPreferences.observeLong(key, (long) defaultValue);
+        preferenceObservable = rxPreferences.getLongStream(key, (long) defaultValue);
         break;
       case FLOAT:
-        preferenceObservable = rxPreferences.observeFloat(key, (float) defaultValue);
+        preferenceObservable = rxPreferences.getFloatStream(key, (float) defaultValue);
         break;
       case BOOLEAN:
-        preferenceObservable = rxPreferences.observeBoolean(key, (boolean) defaultValue);
+        preferenceObservable = rxPreferences.getBooleanStream(key, (boolean) defaultValue);
         break;
       default:
         fail("Unknown preference type: " + type);
@@ -574,11 +576,11 @@ public final class RxPreferencesTest {
 
   //region contains
   @Test
-  public void contains_emitsFromInternalPreferences() {
+  public void containsOnce_emitsFromInternalPreferences() {
     final String testKey = "Test key";
     when(mockSharedPreferences.contains(testKey)).thenReturn(true);
 
-    final TestObserver<Boolean> subscription = rxPreferences.contains(testKey)
+    final TestObserver<Boolean> subscription = rxPreferences.containsOnce(testKey)
         .test();
     subscriptions.add(subscription);
 
@@ -589,11 +591,11 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void contains_getsAfterSubscribe() {
+  public void containsOnce_getsAfterSubscribe() {
     final String testKey = "Test key";
     when(mockSharedPreferences.contains(testKey)).thenReturn(true);
 
-    final Disposable subscription = rxPreferences.contains(testKey)
+    final Disposable subscription = rxPreferences.containsOnce(testKey)
         .subscribeOn(testScheduler)
         .subscribe();
     subscriptions.add(subscription);
@@ -606,11 +608,11 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeContains_emitsOnListenerUpdate() {
+  public void containsStream_emitsOnListenerUpdate() {
     final String testKey = "Test contains key";
     when(mockSharedPreferences.contains(testKey)).thenReturn(true);
 
-    final TestObserver<Boolean> subscription = rxPreferences.observeContains(testKey).test();
+    final TestObserver<Boolean> subscription = rxPreferences.containsStream(testKey).test();
     subscriptions.add(subscription);
 
     subscription
@@ -632,16 +634,16 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeContains_emitsCurrentValueOnSubscribe() {
+  public void containsStream_emitsCurrentValueOnSubscribe() {
     final String testKey = "Test contains key";
     when(mockSharedPreferences.contains(testKey)).thenReturn(true);
 
-    final Disposable subscription = rxPreferences.observeContains(testKey)
+    final Disposable subscription = rxPreferences.containsStream(testKey)
         .subscribeOn(testScheduler)
         .subscribe();
     subscriptions.add(subscription);
 
-    verifyObserveBeforeSubscribe(subscription);
+    verifyGetStreamBeforeSubscribe(subscription);
 
     advanceScheduler();
     // After subscribing, the value is retrieved from the internal preferences:
@@ -652,11 +654,11 @@ public final class RxPreferencesTest {
   }
 
   @Test
-  public void observeContains_unregistersListenerOnUnsubscribe() {
+  public void containsStream_unregistersListenerOnUnsubscribe() {
     final String testKey = "Test contains key";
     when(mockSharedPreferences.contains(testKey)).thenReturn(true);
 
-    final TestObserver<Boolean> subscription = rxPreferences.observeContains(testKey).test();
+    final TestObserver<Boolean> subscription = rxPreferences.containsStream(testKey).test();
     subscriptions.add(subscription);
 
     final ArgumentCaptor<SharedPreferences.OnSharedPreferenceChangeListener> listenerCaptor =


### PR DESCRIPTION
Replace methods named `getPreference` with `getPreferenceOnce` and methods named `observePreference` with `getPreferenceStream`.

Rationale:
* For methods with `Single` return type, the preference is not returned directly, but emitted once upon subscription to the `Single`.
* For methods with `Observable` return type, the values are not observed immediately, but only upon subscription to the `Observable`.